### PR TITLE
modify auth format and add unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/qiniu/api.v7/v7 v7.6.0
 	github.com/qiniu/qmgo v0.7.0
 	github.com/qiniu/x v1.11.5
-	github.com/satori/go.uuid v1.2.0
 	github.com/someonegg/gox v1.0.0
 	github.com/someonegg/msgpump v1.0.0
+	github.com/stretchr/testify v1.4.0
 	go.mongodb.org/mongo-driver v1.4.0
 	go.uber.org/atomic v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,6 @@ github.com/qiniu/x v1.11.5/go.mod h1:03Ni9tj+N2h2aKnAz+6N0Xfl8FwMEDRC2PAlxekASDs
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/handler/account_test.go
+++ b/handler/account_test.go
@@ -1,0 +1,66 @@
+package handler
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/qiniu/x/xlog"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/qrtc/qlive/errors"
+	"github.com/qrtc/qlive/protocol"
+)
+
+func TestSendSMSCode(t *testing.T) {
+	handler := &AccountHandler{
+		Account: &MockAccount{},
+		SMSCode: &MockSMSCode{
+			NumberToError: map[string]error{
+				"19999990000": &errors.ServerError{Code: errors.ServerErrorSMSSendTooFrequent},
+				"19999990001": &errors.ServerError{Code: errors.ServerErrorSMSSendFail},
+			},
+		},
+	}
+	// 构造测试用例列表。
+	testCases := []struct {
+		phoneNumber        string
+		expectedStatusCode int
+	}{
+		{
+			phoneNumber:        "110",
+			expectedStatusCode: 400,
+		},
+		{
+			phoneNumber:        "19999990000",
+			expectedStatusCode: 429,
+		},
+		{
+			phoneNumber:        "19999990001",
+			expectedStatusCode: 500,
+		},
+		{
+			phoneNumber:        "19999990002",
+			expectedStatusCode: 200,
+		},
+	}
+	for i, testCase := range testCases {
+		// 创建 HTTP record，记录返回结果
+		w := httptest.NewRecorder()
+		// 创建测试用 gin context.
+		c, _ := gin.CreateTestContext(w)
+		// 创建xlog.Logger，记录请求处理过程中的日志（handler函数必需）。
+		c.Set(protocol.XLogKey, xlog.New(fmt.Sprintf("test-login-sms-%d", i)))
+		// 构造request.
+		bodyBuf := &bytes.Buffer{}
+		req, err := http.NewRequest("POST", "/v1/send_sms_code?phone_number="+testCase.phoneNumber, bodyBuf)
+		assert.Nilf(t, err, "construct request failed for test case %d, error %v", i, err)
+		c.Request = req
+		// handler处理请求。
+		handler.SendSMSCode(c)
+		assert.Equalf(t, testCase.expectedStatusCode, w.Code, "code is not the same as expectrd for test case %d", i)
+	}
+}

--- a/handler/mock.go
+++ b/handler/mock.go
@@ -77,10 +77,16 @@ func (m *MockAccount) AccountLogout(xl *xlog.Logger, id string) error {
 }
 
 // MockSMSCode 模拟的短信服务。
-type MockSMSCode struct{}
+type MockSMSCode struct {
+	// 模拟发送出错的情况。
+	NumberToError map[string]error
+}
 
 // Send 模拟发送验证码
 func (m *MockSMSCode) Send(xl *xlog.Logger, phoneNumber string) error {
+	if m.NumberToError != nil {
+		return m.NumberToError[phoneNumber]
+	}
 	return nil
 }
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -11,6 +11,12 @@ const (
 	RequestIDHeader = "X-Reqid"
 	// XLogKey gin context中，用于获取记录请求相关日志的 xlog logger的key。
 	XLogKey = "xlog-logger"
+
+	// LoginTokenKey 登录用的token。
+	LoginTokenKey = "qlive-login-token"
+
+	// UserIDContextKey 存放在请求context 中的用户ID。
+	UserIDContextKey = "userID"
 )
 
 // UserInfo 用户的信息，包括ID、昵称等。
@@ -27,13 +33,10 @@ type SMSLoginArgs struct {
 }
 
 // LoginResponse 登录的返回结果。
-type LoginResponse UserInfo
-
-// LoginCookieKey 登录用的token，存放在cookie中。
-const LoginCookieKey = "qlive-login-token"
-
-// UserIDContextKey 存放在请求context 中的用户ID。
-const UserIDContextKey = "userID"
+type LoginResponse struct {
+	UserInfo
+	Token string `json:"token"`
+}
 
 // UpdateProfileArgs 修改用户信息接口。
 type UpdateProfileArgs struct {

--- a/qlive.conf
+++ b/qlive.conf
@@ -1,0 +1,24 @@
+## 配置文件样例。
+{
+    "debug_level":0,
+    "listen_addr": ":8080",
+    "websocket_conf":{
+        "listen_addr":":8443",
+        "serve_uri": "/qlive"
+    },
+    "mongo":{
+        "uri":"mongodb://127.0.0.1:27017",
+        "database": "qrtc_qlive_test"
+    },
+    "sms":{
+        "provider":"qiniu",
+        "qiniu_sms":{
+            "key_pair":{
+                "access_key": "ak", # replace with real ak/sk
+                "secert_key": "sk"
+            },
+            "signature_id":"sign_id", # replace with real singature ID and template ID
+            "template_id":"temp_id"
+        }
+    }
+}


### PR DESCRIPTION
- 修改登录与认证格式，改为使用`Authorizaton:Bearer <token>`格式
- 对同一账号，新的登录取代旧的
- 添加单元测试
- 添加配置文件样例