### PR TITLE
观众人数统计逻辑改动 & 用户进入、创建直播间操作限制

### DIFF
--- a/controller/account.go
+++ b/controller/account.go
@@ -143,7 +143,7 @@ func (c *AccountController) GetActiveUserByFields(xl *xlog.Logger, fields map[st
 	return &activeUser, nil
 }
 
-// GetAccountByID 使用ID查找活跃用户信息。
+// GetActiveUserByID 使用ID查找活跃用户信息。
 func (c *AccountController) GetActiveUserByID(xl *xlog.Logger, id string) (*protocol.ActiveUser, error) {
 	return c.GetActiveUserByFields(xl, bson.M{"_id": id})
 }

--- a/errors/http_errors.go
+++ b/errors/http_errors.go
@@ -33,6 +33,8 @@ const (
 	HTTPErrorNoSuchUser           = 404001
 	HTTPErrorNoSuchRoom           = 404002
 	HTTPErrorRoomNameUsed         = 409002
+	HTTPErrorUserBroadcating      = 409003
+	HTTPErrorUserWatching         = 409004
 	HTTPErrorSMSSendTooFrequent   = 429001
 	HTTPErrorTooManyRooms         = 503001
 	HTTPErrorInternal             = 500000
@@ -174,6 +176,22 @@ func NewHTTPErrorRoomNameused() *HTTPError {
 	return &HTTPError{
 		Code:    HTTPErrorRoomNameUsed,
 		Summary: "room name already used",
+	}
+}
+
+// NewHTTPErrorUserBroadcasting 用户正在直播中，不能进入直播间。
+func NewHTTPErrorUserBroadcasting() *HTTPError {
+	return &HTTPError{
+		Code:    HTTPErrorUserBroadcating,
+		Summary: "user is live broadcasting",
+	}
+}
+
+// NewHTTPErrorUserWatching 用户正在观看中，不能创建直播间。
+func NewHTTPErrorUserWatching() *HTTPError {
+	return &HTTPError{
+		Code:    HTTPErrorUserWatching,
+		Summary: "user is watching",
 	}
 }
 

--- a/errors/server_errors.go
+++ b/errors/server_errors.go
@@ -24,6 +24,8 @@ const (
 	ServerErrorRoomNameUsed         = 10006
 	ServerErrorTooManyRooms         = 10007
 	ServerErrorCanOnlyCreateOneRoom = 10008
+	ServerErrorUserBroadcasting     = 10009
+	ServerErrorUserWatching         = 10010
 	ServerErrorSMSSendTooFrequent   = 10011
 	ServerErrorMongoOpFail          = 11000
 	// 2开头表示外部服务错误。

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,7 @@ github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc h1:n+nNi93yXLkJvKwX
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 go.mongodb.org/mongo-driver v1.4.0 h1:C8rFn1VF4GVEM/rG+dSoMmlm2pyQ9cs2/oRtUATejRU=
 go.mongodb.org/mongo-driver v1.4.0/go.mod h1:llVBH2pkj9HywK0Dtdt6lDikOjFLbceHVu/Rc0iMKLs=
+go.mongodb.org/mongo-driver v1.4.1 h1:38NSAyDPagwnFpUA/D5SFgbugUYR3NzYRNa4Qk9UxKs=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/protocol/db_model.go
+++ b/protocol/db_model.go
@@ -106,8 +106,6 @@ type LiveRoom struct {
 	Status LiveRoomStatus `json:"status" bson:"status"`
 	// PKAnchor 正在该直播间参与PK的另一主播的ID。
 	PKAnchor string `json:"pkAnchor,omitempty" bson:"pkAnchor,omitempty"`
-	// Audiences 观众ID列表。
-	Audiences []string `json:"audiences" bson:"audiences"`
 	// IMGroup 该直播间关联聊天群组。
 	IMChatRoom string `json:"imGroup" bson:"imGroup"`
 }

--- a/service/gin_router.go
+++ b/service/gin_router.go
@@ -108,6 +108,7 @@ func addRequestID(c *gin.Context) {
 		c.Request.Header.Set(protocol.RequestIDHeader, requestID)
 	}
 	xl := xlog.New(requestID)
+	xl.Debugf("request: %s %s", c.Request.Method, c.Request.URL.Path)
 	c.Set(protocol.XLogKey, xl)
 }
 


### PR DESCRIPTION
 - 创建直播间时检查用户状态，观看中的不能再创建
 - 进入/退出直播间时检查用户状态，直播中的不能进入其他直播间
 - 修改观众人数统计逻辑，去掉数据库中`room`的`audiences`字段，根据`active_users`表的用户状态统计直播间观众数