### PR TITLE
fix pk room cannot get pk anchor

### DIFF
--- a/handler/account_test.go
+++ b/handler/account_test.go
@@ -18,8 +18,8 @@ import (
 
 func TestSendSMSCode(t *testing.T) {
 	handler := &AccountHandler{
-		Account: &MockAccount{},
-		SMSCode: &MockSMSCode{
+		Account: &mockAccount{},
+		SMSCode: &mockSMSCode{
 			NumberToError: map[string]error{
 				"19999990000": &errors.ServerError{Code: errors.ServerErrorSMSSendTooFrequent},
 				"19999990001": &errors.ServerError{Code: errors.ServerErrorSMSSendFail},
@@ -69,8 +69,8 @@ func TestSendSMSCode(t *testing.T) {
 
 func TestLogin(t *testing.T) {
 	handler := &AccountHandler{
-		Account: &MockAccount{},
-		SMSCode: &MockSMSCode{},
+		Account: &mockAccount{},
+		SMSCode: &mockSMSCode{},
 	}
 
 	testCases := []struct {
@@ -124,12 +124,12 @@ func TestLogin(t *testing.T) {
 
 func TestUpdateProfile(t *testing.T) {
 	handler := &AccountHandler{
-		Account: &MockAccount{
+		Account: &mockAccount{
 			accounts: []*protocol.Account{
 				{ID: "user-0"},
 			},
 		},
-		SMSCode: &MockSMSCode{},
+		SMSCode: &mockSMSCode{},
 	}
 	testCases := []struct {
 		userID             string

--- a/handler/auth_test.go
+++ b/handler/auth_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAuthenticate(t *testing.T) {
 	handler := &AuthHandler{
-		Auth: &MockAuth{},
+		Auth: &mockAuth{},
 	}
 	testCases := []struct {
 		authHeader         string

--- a/handler/im.go
+++ b/handler/im.go
@@ -20,7 +20,7 @@ type IMHandler struct {
 	IMService IMInterface
 }
 
-// GetUserToken 获取用户token。
+// GetUserToken 获取IM用户token。
 func (h *IMHandler) GetUserToken(c *gin.Context) {
 	xl := c.MustGet(protocol.XLogKey).(*xlog.Logger)
 	requestID := xl.ReqId

--- a/handler/mock.go
+++ b/handler/mock.go
@@ -9,11 +9,11 @@ import (
 )
 
 // MockAccount 模拟的账号服务。
-type MockAccount struct {
+type mockAccount struct {
 	accounts []*protocol.Account
 }
 
-func (m *MockAccount) GetAccountByPhoneNumber(xl *xlog.Logger, phoneNumber string) (*protocol.Account, error) {
+func (m *mockAccount) GetAccountByPhoneNumber(xl *xlog.Logger, phoneNumber string) (*protocol.Account, error) {
 	for _, account := range m.accounts {
 		if account.PhoneNumber == phoneNumber {
 			return account, nil
@@ -22,7 +22,7 @@ func (m *MockAccount) GetAccountByPhoneNumber(xl *xlog.Logger, phoneNumber strin
 	return nil, fmt.Errorf("not found")
 }
 
-func (m *MockAccount) GetAccountByID(xl *xlog.Logger, id string) (*protocol.Account, error) {
+func (m *mockAccount) GetAccountByID(xl *xlog.Logger, id string) (*protocol.Account, error) {
 	for _, account := range m.accounts {
 		if account.ID == id {
 			return account, nil
@@ -31,7 +31,7 @@ func (m *MockAccount) GetAccountByID(xl *xlog.Logger, id string) (*protocol.Acco
 	return nil, fmt.Errorf("not found")
 }
 
-func (m *MockAccount) CreateAccount(xl *xlog.Logger, account *protocol.Account) error {
+func (m *mockAccount) CreateAccount(xl *xlog.Logger, account *protocol.Account) error {
 	if account.ID == "" || account.PhoneNumber == "" {
 		return fmt.Errorf("bad request")
 	}
@@ -44,7 +44,7 @@ func (m *MockAccount) CreateAccount(xl *xlog.Logger, account *protocol.Account) 
 	return nil
 }
 
-func (m *MockAccount) UpdateAccount(xl *xlog.Logger, id string, account *protocol.Account) (*protocol.Account, error) {
+func (m *mockAccount) UpdateAccount(xl *xlog.Logger, id string, account *protocol.Account) (*protocol.Account, error) {
 	if account.ID != "" && account.ID != id {
 		return nil, fmt.Errorf("bad request")
 	}
@@ -67,23 +67,23 @@ func (m *MockAccount) UpdateAccount(xl *xlog.Logger, id string, account *protoco
 }
 
 // AccountLogin 模拟账号登录，返回token。
-func (m *MockAccount) AccountLogin(xl *xlog.Logger, id string) (token string, err error) {
+func (m *mockAccount) AccountLogin(xl *xlog.Logger, id string) (token string, err error) {
 	return id + "#" + "login-token", nil
 }
 
 // AccountLogout 模拟账号退出登录。
-func (m *MockAccount) AccountLogout(xl *xlog.Logger, id string) error {
+func (m *mockAccount) AccountLogout(xl *xlog.Logger, id string) error {
 	return nil
 }
 
-// MockSMSCode 模拟的短信服务。
-type MockSMSCode struct {
+// mockSMSCode 模拟的短信服务。
+type mockSMSCode struct {
 	// 模拟发送出错的情况。
 	NumberToError map[string]error
 }
 
 // Send 模拟发送验证码
-func (m *MockSMSCode) Send(xl *xlog.Logger, phoneNumber string) error {
+func (m *mockSMSCode) Send(xl *xlog.Logger, phoneNumber string) error {
 	if m.NumberToError != nil {
 		return m.NumberToError[phoneNumber]
 	}
@@ -91,18 +91,18 @@ func (m *MockSMSCode) Send(xl *xlog.Logger, phoneNumber string) error {
 }
 
 // Validate 模拟检查输入的验证码。
-func (m *MockSMSCode) Validate(xl *xlog.Logger, phoneNumber string, smsCode string) error {
+func (m *mockSMSCode) Validate(xl *xlog.Logger, phoneNumber string, smsCode string) error {
 	if smsCode == "123456" {
 		return nil
 	}
 	return fmt.Errorf("wrong sms code")
 }
 
-// MockAuth 模拟的认证服务。
-type MockAuth struct{}
+// mockAuth 模拟的认证服务。
+type mockAuth struct{}
 
 // GetIDByToken 从token 中获取用户ID。
-func (m *MockAuth) GetIDByToken(xl *xlog.Logger, token string) (string, error) {
+func (m *mockAuth) GetIDByToken(xl *xlog.Logger, token string) (string, error) {
 	parts := strings.SplitN(token, "#", 2)
 	if len(parts) < 2 {
 		return "", fmt.Errorf("invalid token")
@@ -110,5 +110,5 @@ func (m *MockAuth) GetIDByToken(xl *xlog.Logger, token string) (string, error) {
 	return parts[0], nil
 }
 
-// MockRoom 模拟的房间管理服务。
-type MockRoom struct{}
+// mockRoom 模拟的房间管理服务。
+type mockRoom struct{}

--- a/service/ws_service.go
+++ b/service/ws_service.go
@@ -492,6 +492,7 @@ func (c *WSClient) onAnswerPK(ctx context.Context, m msgpump.Message) {
 		selfRoom.Status = protocol.LiveRoomStatusPK
 		selfRoom.PKAnchor = pkPlayer.ID
 		pkRoom.Status = protocol.LiveRoomStatusPK
+		pkRoom.PKAnchor = selfPlayer.ID
 		selfActiveUser.Status = protocol.UserStatusPKLive
 		pkActiveUser.Status = protocol.UserStatusPKLive
 		pkActiveUser.Room = selfRoom.ID
@@ -679,6 +680,7 @@ func (c *WSClient) onEndPK(ctx context.Context, m msgpump.Message) {
 	pkRoom.PKAnchor = ""
 	pkRoom.Status = protocol.LiveRoomStatusSingle
 	otherRoom.Status = protocol.LiveRoomStatusSingle
+	otherRoom.PKAnchor = ""
 	selfActiveUser.Status = protocol.UserStatusSingleLive
 	otherActiveUser.Status = protocol.UserStatusSingleLive
 	if selfPlayer.ID == pkRoom.Creator {


### PR DESCRIPTION
pk 开始时，两个房间都将`pkAnchor`设置为对方以修复无法获取主播信息问题。