### PR TITLE
添加配置，允许自行指定对外返回的websocket地址或端口

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,9 +9,14 @@ type WebSocketConf struct {
 	PongTimeoutSecond      int `json:"pong_timeout_s"`
 	ReconnectTimeoutSecond int `json:"reconnect_timeout_s"`
 
-	ListenAddr      string `json:"listen_addr" validate:"nonzero"`
-	ServeURI        string `json:"serve_uri" validate:"nonzero"`
-	WSOverTLS       bool   `json:"ws_over_tls"`
+	ListenAddr string `json:"listen_addr" validate:"nonzero"`
+	ServeURI   string `json:"serve_uri" validate:"nonzero"`
+	WSOverTLS  bool   `json:"ws_over_tls"`
+	// 对外返回的websocket 服务地址。为空时将根据请求信息自动生成。
+	ExternalWSAddr string `json:"external_ws_addr"`
+	// 当ExternalWSAddr为空时，且ExternalWSPort被指定，根据请求信息中的host+ExternalWSPort确定对外返回的websocket地址。
+	ExternalWSPort int `json:"external_ws_port"`
+
 	PumpWriteQueue  int    `json:"pump_write_queue" validate:"nonzero"`
 	OriginHost      string `json:"origin_host"`
 	ReadBufferSize  int    `json:"conn_read_size"`

--- a/handler/room_test.go
+++ b/handler/room_test.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/qiniu/x/xlog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGeneratewsURL(t *testing.T) {
+	xlog.SetOutputLevel(0)
+	h := &RoomHandler{}
+	testCases := []struct {
+		wsAddress   string
+		wsProtocol  string
+		wsPort      int
+		wsPath      string
+		host        string
+		expectedURL string
+	}{
+
+		{
+			wsAddress:   "wss://localhost:1234/qlive",
+			wsProtocol:  "wss",
+			wsPort:      8081,
+			wsPath:      "/qlive",
+			host:        "127.0.0.1",
+			expectedURL: "wss://localhost:1234/qlive",
+		},
+		{
+			wsAddress:   "localhost:1234/qlive",
+			wsProtocol:  "wss",
+			wsPort:      8081,
+			wsPath:      "/qlive",
+			host:        "127.0.0.1",
+			expectedURL: "wss://localhost:1234/qlive",
+		},
+		{
+			wsAddress:   "",
+			wsProtocol:  "ws",
+			wsPort:      8081,
+			wsPath:      "/qlive",
+			host:        "127.0.0.1",
+			expectedURL: "ws://127.0.0.1:8081/qlive",
+		},
+		{
+			wsAddress:   "",
+			wsProtocol:  "wss",
+			wsPort:      8081,
+			wsPath:      "/qlive",
+			host:        "127.0.0.1:8080",
+			expectedURL: "wss://127.0.0.1:8081/qlive",
+		},
+		{
+			wsAddress:   "",
+			wsProtocol:  "ws",
+			wsPort:      80,
+			wsPath:      "/qlive",
+			host:        "127.0.0.1:8080",
+			expectedURL: "ws://127.0.0.1/qlive",
+		},
+		{
+			wsAddress:   "",
+			wsProtocol:  "wss",
+			wsPort:      443,
+			wsPath:      "/qlive",
+			host:        "127.0.0.1:80",
+			expectedURL: "wss://127.0.0.1/qlive",
+		},
+	}
+	for i, testCase := range testCases {
+		h.WSAddress = testCase.wsAddress
+		h.WSProtocol = testCase.wsProtocol
+		h.WSPort = testCase.wsPort
+		h.WSPath = testCase.wsPath
+		xl := xlog.New(fmt.Sprintf("test-generatewsURL-%d", i))
+		wsURL := h.generateWSURL(xl, testCase.host)
+		assert.Equalf(t, testCase.expectedURL, wsURL, "test case %d: URL does not match", i)
+	}
+}


### PR DESCRIPTION
添加 external_ws_addr ， external_ws_port 两个配置，允许自行指定对外返回的websocket地址或端口
external_ws_addr 优先生效，配置external_ws_addr时，直接返回该值作为websocket服务地址。
external_ws_port 指定时，将取代listen_addr 中的端口，返回的websocket地址中的端口使用该指定值。