### PR TITLE
修改融云用户状态的解析方式

### DIFF
--- a/protocol/http_model.go
+++ b/protocol/http_model.go
@@ -221,7 +221,7 @@ type RongCloudMessageContent struct {
 }
 
 // RongCloudUserStatusResp 融云的用户状态变化回调的消息体。
-type RongCloudUserStatusResp struct {
+type RongCloudUserStatus struct {
 	Signature   RongCloudSignature `form:"-"`
 	UserID      string             `form:"userid" json:"userid"`
 	Status      string             `form:"status" json:"status"`
@@ -231,12 +231,12 @@ type RongCloudUserStatusResp struct {
 }
 
 // RongCloudUserStatus 融云用户状态变化回调中指定的用户的在线状态，分为 0 在线、1 离线、2 登出。
-type RongCloudUserStatus string
+type RongCloudUserOnlineStatus string
 
 const (
-	RongCloudUserOnline  RongCloudUserStatus = "0"
-	RongClouduserOffline RongCloudUserStatus = "1"
-	RongCloudUserLogout  RongCloudUserStatus = "2"
+	RongCloudUserOnline  RongCloudUserOnlineStatus = "0"
+	RongClouduserOffline RongCloudUserOnlineStatus = "1"
+	RongCloudUserLogout  RongCloudUserOnlineStatus = "2"
 )
 
 // GetUploadTokenArgs 获取上传文件token的参数。


### PR DESCRIPTION
融云订阅用户在线状态的API格式经测试为如下格式
```
curl -o /dev/null -s -w %{http_code} -H "Content-Type:application/x-www-form-urlencoded" -H "User-Agent:RongCloud/1.0" -X POST -d "0[userid]=测试用户ID" -d "0[status]=在线状态" -d "0[os]=操作平台" -d "0[time]=1603951326000" -d "0[clientIp]=客户端 IP 地址" https://qlive-api-test.qnsdk.com/v1/im_user_status/rongcloud?signTimestamp=1603951326000&nonce=1639123951&signature=acd7a9aca1d45722ddb2515a8b4f173f23a3b125
```
为post-form格式，非文档中说明的json格式，因此需要修改解析用户状态的逻辑。