### PR TITLE
QRTC-830 HTTP API support voice room and avatar

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -138,6 +138,8 @@ type Config struct {
 	// debug等级，为1时输出info/warn/error日志，为0除以上外还输出debug日志
 	DebugLevel int    `json:"debug_level"`
 	ListenAddr string `json:"listen_addr"`
+	// 默认头像列表，用户新注册时随机从中选取一个作为初始头像。
+	DefaultAvatars []string `json:"default_avatars"`
 
 	WsConf       *WebSocketConf      `json:"websocket_conf"`
 	Signaling    *SignalingConfig    `json:"signaling"`
@@ -153,8 +155,9 @@ type Config struct {
 // NewSample 返回样例配置。
 func NewSample() *Config {
 	return &Config{
-		DebugLevel: 0,
-		ListenAddr: ":8080",
+		DebugLevel:     0,
+		ListenAddr:     ":8080",
+		DefaultAvatars: []string{"1.jpg"},
 		WsConf: &WebSocketConf{
 			ListenAddr: ":8082",
 			ServeURI:   "/qlive",

--- a/controller/account.go
+++ b/controller/account.go
@@ -115,6 +115,9 @@ func (c *AccountController) UpdateAccount(xl *xlog.Logger, id string, newAccount
 	if newAccount.Gender != "" {
 		account.Gender = newAccount.Gender
 	}
+	if newAccount.AvatarURL != "" {
+		account.AvatarURL = newAccount.AvatarURL
+	}
 	err = c.accountColl.UpdateOne(context.Background(), bson.M{"_id": id}, bson.M{"$set": account})
 	if err != nil {
 		xl.Errorf("failed to update account %s,error %v", id, err)

--- a/controller/signaling.go
+++ b/controller/signaling.go
@@ -146,6 +146,19 @@ func (s *SignalingService) OnStartPK(xl *xlog.Logger, senderID string, msgBody [
 		s.Notify(xl, senderID, protocol.MT_StartResponse, res)
 		return err
 	}
+	// 检查房间是否为主播PK房。
+	if pkRoom.Type != protocol.RoomTypePK {
+		// 兼容没有指定type的旧房间
+		if string(pkRoom.Type) != "" {
+			res := &protocol.StartPKResponse{
+				RPCID: req.RPCID,
+				Code:  errors.WSErrorRoomTypeWrong,
+				Error: errors.WSErrorToString[errors.WSErrorRoomTypeWrong],
+			}
+			s.Notify(xl, senderID, protocol.MT_StartResponse, res)
+			return fmt.Errorf("invalid room type %s", pkRoom.Type)
+		}
+	}
 	if pkRoom.Status != protocol.LiveRoomStatusSingle {
 		res := &protocol.StartPKResponse{
 			RPCID: req.RPCID,

--- a/errors/http_errors.go
+++ b/errors/http_errors.go
@@ -37,6 +37,7 @@ const (
 	HTTPErrorInvalidPhoneNumber   = 400001
 	HTTPErrorInvalidRoomName      = 400004
 	HTTPErrorBadLoginType         = 400005
+	HTTPErrorBadRoomType          = 400007
 	HTTPErrorUnauthorized         = 401000
 	HTTPErrorNotLoggedIn          = 401001
 	HTTPErrorWrongSMSCode         = 401002
@@ -110,6 +111,14 @@ func NewHTTPErrorBadLoginType() *HTTPError {
 	return &HTTPError{
 		Code:    HTTPErrorBadLoginType,
 		Summary: "unsupported login type",
+	}
+}
+
+// NewHTTPErrorBadRoomType 不支持的房间类型。
+func NewHTTPErrorBadRoomType() *HTTPError {
+	return &HTTPError{
+		Code:    HTTPErrorBadRoomType,
+		Summary: "unsupported room type",
 	}
 }
 

--- a/errors/http_errors.go
+++ b/errors/http_errors.go
@@ -50,6 +50,7 @@ const (
 	HTTPErrorRoomNameUsed         = 409002
 	HTTPErrorUserBroadcating      = 409003
 	HTTPErrorUserWatching         = 409004
+	HTTPErrorUserJoined           = 409005
 	HTTPErrorSMSSendTooFrequent   = 429001
 	HTTPErrorTooManyRooms         = 503001
 	HTTPErrorInternal             = 500000
@@ -215,6 +216,14 @@ func NewHTTPErrorUserWatching() *HTTPError {
 	return &HTTPError{
 		Code:    HTTPErrorUserWatching,
 		Summary: "user is watching",
+	}
+}
+
+// NewHTTPErrorUserJoined 用户已经加入连麦，不能创建直播间或进入其他直播间。
+func NewHTTPErrorUserJoined() *HTTPError {
+	return &HTTPError{
+		Code:    HTTPErrorUserJoined,
+		Summary: "user joined",
 	}
 }
 

--- a/errors/server_errors.go
+++ b/errors/server_errors.go
@@ -41,6 +41,7 @@ const (
 	ServerErrorUserBroadcasting     = 10009
 	ServerErrorUserWatching         = 10010
 	ServerErrorSMSSendTooFrequent   = 10011
+	ServerErrorUserJoined           = 10012
 	ServerErrorMongoOpFail          = 11000
 	// 2开头表示外部服务错误。
 	ServerErrorSMSSendFail = 20001

--- a/errors/ws_errors.go
+++ b/errors/ws_errors.go
@@ -22,6 +22,7 @@ const (
 	WSErrorRoomNoExist      = 10011
 	WSErrorRoomInPK         = 10012
 	WSErrorRoomNotInPK      = 10013
+	WSErrorRoomTypeWrong    = 10014 // 房间类型不符合，不能发起PK/连麦请求
 	WSErrorPlayerNoExist    = 10021
 	WSErrorPlayerOffline    = 10022
 	WSErrorInvalidParameter = 10031
@@ -35,6 +36,7 @@ var WSErrorToString = map[int]string{
 	WSErrorRoomNoExist:      "room no exist",
 	WSErrorRoomInPK:         "room in PK",
 	WSErrorRoomNotInPK:      "room not in PK",
+	WSErrorRoomTypeWrong:    "room type does not support the request",
 	WSErrorPlayerNoExist:    "player no exist",
 	WSErrorPlayerOffline:    "player offline",
 	WSErrorInvalidParameter: "invalid parameter",

--- a/handler/account.go
+++ b/handler/account.go
@@ -44,8 +44,9 @@ type SMSCodeInterface interface {
 
 // AccountHandler 处理与账号相关的请求：登录、注册、退出、修改账号信息等
 type AccountHandler struct {
-	Account AccountInterface
-	SMSCode SMSCodeInterface
+	Account           AccountInterface
+	SMSCode           SMSCodeInterface
+	DefaultAvatarURLs []string
 }
 
 // validatePhoneNumber 检查手机号码是否符合规则。
@@ -154,6 +155,14 @@ func (h *AccountHandler) generateNicknameByPhoneNumber(phoneNumber string) strin
 	return namePrefix + phoneNumber[len(phoneNumber)-4:]
 }
 
+func (h *AccountHandler) generateInitialAvatar() string {
+	if len(h.DefaultAvatarURLs) == 0 {
+		return ""
+	}
+	index := rand.Intn(len(h.DefaultAvatarURLs))
+	return h.DefaultAvatarURLs[index]
+}
+
 // LoginBySMS 使用手机短信验证码登录。
 func (h *AccountHandler) LoginBySMS(c *gin.Context) {
 	xl := c.MustGet(protocol.XLogKey).(*xlog.Logger)
@@ -182,6 +191,7 @@ func (h *AccountHandler) LoginBySMS(c *gin.Context) {
 				ID:          h.generateUserID(),
 				Nickname:    h.generateNicknameByPhoneNumber(args.PhoneNumber),
 				PhoneNumber: args.PhoneNumber,
+				AvatarURL:   h.generateInitialAvatar(),
 			}
 			createErr := h.Account.CreateAccount(xl, newAccount)
 			if createErr != nil {

--- a/handler/account.go
+++ b/handler/account.go
@@ -216,9 +216,10 @@ func (h *AccountHandler) LoginBySMS(c *gin.Context) {
 
 	res := &protocol.LoginResponse{
 		UserInfo: protocol.UserInfo{
-			ID:       account.ID,
-			Nickname: account.Nickname,
-			Gender:   account.Gender,
+			ID:        account.ID,
+			Nickname:  account.Nickname,
+			Gender:    account.Gender,
+			AvatarURL: account.AvatarURL,
 		},
 		Token:  user.Token,
 		Status: string(user.Status),
@@ -276,6 +277,9 @@ func (h *AccountHandler) UpdateProfile(c *gin.Context) {
 	if args.Gender != "" {
 		account.Gender = args.Gender
 	}
+	if args.AvatarURL != "" {
+		account.AvatarURL = args.AvatarURL
+	}
 
 	newAccount, err := h.Account.UpdateAccount(xl, id, account)
 	if err != nil {
@@ -284,9 +288,10 @@ func (h *AccountHandler) UpdateProfile(c *gin.Context) {
 		return
 	}
 	ret := &protocol.UpdateProfileResponse{
-		ID:       newAccount.ID,
-		Nickname: newAccount.Nickname,
-		Gender:   newAccount.Gender,
+		ID:        newAccount.ID,
+		Nickname:  newAccount.Nickname,
+		Gender:    newAccount.Gender,
+		AvatarURL: newAccount.AvatarURL,
 	}
 	c.JSON(http.StatusOK, ret)
 }

--- a/handler/account_test.go
+++ b/handler/account_test.go
@@ -89,6 +89,7 @@ func TestLogin(t *testing.T) {
 					PhoneNumber: "19999990002",
 					ID:          "user-1",
 					Nickname:    "user01",
+					AvatarURL:   "files.example.com/1.jpg",
 				},
 			},
 		},
@@ -101,6 +102,7 @@ func TestLogin(t *testing.T) {
 		smsCode            string
 		expectedStatusCode int
 		userID             string
+		avatarURL          string
 	}{
 		{
 			loginType:          "invalid",
@@ -112,6 +114,7 @@ func TestLogin(t *testing.T) {
 			smsCode:            "123456",
 			expectedStatusCode: 200,
 			userID:             "user-1",
+			avatarURL:          "files.example.com/1.jpg",
 		},
 		{
 			loginType:          "smscode",
@@ -165,12 +168,14 @@ func TestUpdateProfile(t *testing.T) {
 		userID             string
 		nickname           string
 		gender             string
+		avatarURL          string
 		expectedStatusCode int
 	}{
 		{
 			userID:             "user-0",
 			nickname:           "Alice",
 			gender:             "female",
+			avatarURL:          "test.example.com/f.jpg",
 			expectedStatusCode: 200,
 		},
 		{
@@ -187,8 +192,9 @@ func TestUpdateProfile(t *testing.T) {
 		c.Set(protocol.XLogKey, xlog.New(fmt.Sprintf("test-update-profile-%d", i)))
 		c.Set(protocol.UserIDContextKey, testCase.userID)
 		profileReq := &protocol.UpdateProfileArgs{
-			Nickname: testCase.nickname,
-			Gender:   testCase.gender,
+			Nickname:  testCase.nickname,
+			Gender:    testCase.gender,
+			AvatarURL: testCase.avatarURL,
 		}
 
 		buf, err := json.Marshal(profileReq)

--- a/handler/account_test.go
+++ b/handler/account_test.go
@@ -93,13 +93,15 @@ func TestLogin(t *testing.T) {
 				},
 			},
 		},
-		SMSCode: &mockSMSCode{},
+		SMSCode:           &mockSMSCode{},
+		DefaultAvatarURLs: []string{"files.example.com/default.jpg"},
 	}
 
 	testCases := []struct {
 		loginType          string
 		phoneNumber        string
 		smsCode            string
+		newUser            bool
 		expectedStatusCode int
 		userID             string
 		avatarURL          string
@@ -115,6 +117,15 @@ func TestLogin(t *testing.T) {
 			expectedStatusCode: 200,
 			userID:             "user-1",
 			avatarURL:          "files.example.com/1.jpg",
+		},
+		{
+			loginType:          "smscode",
+			phoneNumber:        "19999990004",
+			smsCode:            "123456",
+			newUser:            true,
+			expectedStatusCode: 200,
+			userID:             "user-1",
+			avatarURL:          "files.example.com/default.jpg",
 		},
 		{
 			loginType:          "smscode",
@@ -150,7 +161,10 @@ func TestLogin(t *testing.T) {
 			resp := protocol.LoginResponse{}
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			assert.Nilf(t, err, "failed to read response for test case %d, error %v", i, err)
-			assert.Equalf(t, testCase.userID, resp.ID, "user ID is not same for test case %d", i)
+			if !testCase.newUser {
+				assert.Equalf(t, testCase.userID, resp.ID, "user ID is not same for test case %d", i)
+				assert.Equalf(t, testCase.avatarURL, resp.AvatarURL, "user avatar is not same for test case %d", i)
+			}
 		}
 	}
 }
@@ -182,6 +196,7 @@ func TestUpdateProfile(t *testing.T) {
 			userID:             "user-1",
 			nickname:           "Bob",
 			gender:             "male",
+			avatarURL:          "test.example.com/m.jpg",
 			expectedStatusCode: 404,
 		},
 	}

--- a/handler/room.go
+++ b/handler/room.go
@@ -15,6 +15,7 @@
 package handler
 
 import (
+	"fmt"
 	"math/rand"
 	"net"
 	"net/http"
@@ -93,6 +94,58 @@ func (h *RoomHandler) ListRooms(c *gin.Context) {
 	h.ListAllRooms(c)
 }
 
+func (h *RoomHandler) makeGetRoomResponse(xl *xlog.Logger, room *protocol.LiveRoom) (*protocol.GetRoomResponse, error) {
+	if room == nil {
+		return nil, fmt.Errorf("nil room")
+	}
+	creatorInfo, err := h.Account.GetAccountByID(xl, room.Creator)
+	if err != nil {
+		xl.Errorf("failed to get account info for user %s, creator of room %s", room.Creator, room.ID)
+		// TODO：创建者用户信息获取失败，是否要算这个房间? 现在是添加一个模拟的用户信息
+		creatorInfo = &protocol.Account{ID: room.Creator, Nickname: "user-" + room.Creator}
+	}
+	audienceNumber, err := h.Room.GetAudienceNumber(xl, room.ID)
+	if err != nil {
+		xl.Errorf("failed to get audience number of room %s, error %v", room.ID, err)
+	}
+	roomType := room.Type
+	if string(roomType) == "" {
+		// 兼容之前创建的没有type字段的房间。
+		roomType = protocol.RoomTypePK
+	}
+	getRoomResp := protocol.GetRoomResponse{
+		ID:   room.ID,
+		Name: room.Name,
+		Type: string(roomType),
+		Creator: protocol.UserInfo{
+			ID:        room.Creator,
+			Nickname:  creatorInfo.Nickname,
+			Gender:    creatorInfo.Gender,
+			AvatarURL: creatorInfo.AvatarURL,
+		},
+		PlayURL:        room.PlayURL,
+		AudienceNumber: audienceNumber,
+		Status:         string(room.Status),
+	}
+	if room.Status == protocol.LiveRoomStatusPK {
+		pkAnchorInfo, err := h.Account.GetAccountByID(xl, room.PKAnchor)
+		if err == nil {
+			getRoomResp.PKAnchor = &protocol.UserInfo{
+				ID:        room.PKAnchor,
+				Nickname:  pkAnchorInfo.Nickname,
+				Gender:    pkAnchorInfo.Gender,
+				AvatarURL: pkAnchorInfo.AvatarURL,
+			}
+		} else {
+			getRoomResp.PKAnchor = &protocol.UserInfo{
+				ID: room.PKAnchor,
+			}
+		}
+	}
+	// TODO:若为语音房，添加上麦观众信息。
+	return &getRoomResp, nil
+}
+
 // ListCanPKRooms 列出当前主播可以PK的房间列表。
 func (h *RoomHandler) ListCanPKRooms(c *gin.Context) {
 	xl := c.MustGet(protocol.XLogKey).(*xlog.Logger)
@@ -110,29 +163,21 @@ func (h *RoomHandler) ListCanPKRooms(c *gin.Context) {
 	}
 	resp := &protocol.ListRoomsResponse{}
 	for _, room := range rooms {
-		creatorInfo, err := h.Account.GetAccountByID(xl, room.Creator)
+		// 获取房间类型。
+		roomType := room.Type
+		if string(roomType) == "" {
+			// 兼容之前创建的没有type字段的房间。
+			roomType = protocol.RoomTypePK
+		}
+		if roomType != protocol.RoomTypePK {
+			continue
+		}
+		getRoomResp, err := h.makeGetRoomResponse(xl, &room)
 		if err != nil {
-			xl.Errorf("failed to get account info for user %s, creator of room %s", room.Creator, room.ID)
-			// TODO：创建者用户信息获取失败，是否要算这个房间? 现在是添加一个模拟的用户信息
-			creatorInfo = &protocol.Account{ID: room.Creator, Nickname: "user-" + room.Creator}
+			xl.Errorf("failed to make get room response for room %s", room.ID)
+			continue
 		}
-		audienceNumber, err := h.Room.GetAudienceNumber(xl, room.ID)
-		if err != nil {
-			xl.Errorf("failed to get audience number of room %s, error %v", room.ID, err)
-		}
-		getRoomResp := protocol.GetRoomResponse{
-			ID:   room.ID,
-			Name: room.Name,
-			Creator: protocol.UserInfo{
-				ID:       room.Creator,
-				Nickname: creatorInfo.Nickname,
-				Gender:   creatorInfo.Gender,
-			},
-			PlayURL:        room.PlayURL,
-			AudienceNumber: audienceNumber,
-			Status:         string(room.Status),
-		}
-		resp.Rooms = append(resp.Rooms, getRoomResp)
+		resp.Rooms = append(resp.Rooms, *getRoomResp)
 	}
 	c.JSON(http.StatusOK, resp)
 }
@@ -154,30 +199,14 @@ func (h *RoomHandler) ListRoomsByCreator(c *gin.Context) {
 		return
 	}
 	resp := &protocol.ListRoomsResponse{}
-	creatorInfo, err := h.Account.GetAccountByID(xl, creatorID)
-	if err != nil {
-		xl.Errorf("failed to get account info of creator %s, error %v", creatorID, err)
-		// TODO：创建者用户信息获取失败，是否要算这个房间? 现在是添加一个模拟的用户信息
-		creatorInfo = &protocol.Account{ID: creatorID, Nickname: "user-" + creatorID}
-	}
 	for _, room := range rooms {
-		audienceNumber, err := h.Room.GetAudienceNumber(xl, room.ID)
+		// 获取房间类型。
+		getRoomResp, err := h.makeGetRoomResponse(xl, &room)
 		if err != nil {
-			xl.Errorf("failed to get audience number of room %s, error %v", room.ID, err)
+			xl.Errorf("failed to make get room response for room %s", room.ID)
+			continue
 		}
-		getRoomResp := protocol.GetRoomResponse{
-			ID:   room.ID,
-			Name: room.Name,
-			Creator: protocol.UserInfo{
-				ID:       room.Creator,
-				Nickname: creatorInfo.Nickname,
-				Gender:   creatorInfo.Gender,
-			},
-			PlayURL:        room.PlayURL,
-			AudienceNumber: audienceNumber,
-			Status:         string(room.Status),
-		}
-		resp.Rooms = append(resp.Rooms, getRoomResp)
+		resp.Rooms = append(resp.Rooms, *getRoomResp)
 	}
 	c.JSON(http.StatusOK, resp)
 
@@ -200,34 +229,12 @@ func (h *RoomHandler) ListAllRooms(c *gin.Context) {
 			// 隐藏自己创建的房间
 			continue
 		}
-		creatorInfo, err := h.Account.GetAccountByID(xl, room.Creator)
+		getRoomResp, err := h.makeGetRoomResponse(xl, &room)
 		if err != nil {
-			xl.Errorf("failed to get account info for user %s, creator of room %s", room.Creator, room.ID)
-			// TODO：创建者用户信息获取失败，是否要算这个房间? 现在是添加一个模拟的用户信息
-			creatorInfo = &protocol.Account{ID: room.Creator, Nickname: "user-" + room.Creator}
+			xl.Errorf("failed to make get room response for room %s", room.ID)
+			continue
 		}
-		audienceNumber, err := h.Room.GetAudienceNumber(xl, room.ID)
-		if err != nil {
-			xl.Errorf("failed to get audience number of room %s, error %v", room.ID, err)
-		}
-		getRoomResp := protocol.GetRoomResponse{
-			ID:   room.ID,
-			Name: room.Name,
-			Creator: protocol.UserInfo{
-				ID:       room.Creator,
-				Nickname: creatorInfo.Nickname,
-				Gender:   creatorInfo.Gender,
-			},
-			PlayURL:        room.PlayURL,
-			AudienceNumber: audienceNumber,
-			Status:         string(room.Status),
-		}
-		if room.Status == protocol.LiveRoomStatusPK {
-			getRoomResp.PKAnchor = &protocol.UserInfo{
-				ID: room.PKAnchor,
-			}
-		}
-		resp.Rooms = append(resp.Rooms, getRoomResp)
+		resp.Rooms = append(resp.Rooms, *getRoomResp)
 	}
 	c.JSON(http.StatusOK, resp)
 }
@@ -266,11 +273,19 @@ func (h *RoomHandler) CreateRoom(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, httpErr)
 		return
 	}
+	roomType, err := h.convertRoomType(args.RoomType)
+	if err != nil {
+		xl.Infof("invalid room type %s", args.RoomType)
+		httpErr := errors.NewHTTPErrorBadRoomType().WithRequestID(requestID).WithMessagef("unsupported room type: %s", args.RoomType)
+		c.JSON(http.StatusBadRequest, httpErr)
+		return
+	}
 
 	roomID := h.generateRoomID()
 	room := &protocol.LiveRoom{
 		ID:         roomID,
 		Name:       args.RoomName,
+		Type:       roomType,
 		Creator:    userID,
 		PublishURL: h.generatePublishURL(roomID),
 		PlayURL:    h.generatePlayURL(roomID),
@@ -324,6 +339,17 @@ func (h *RoomHandler) validateRoomName(roomName string) bool {
 		return false
 	}
 	return true
+}
+
+// convertRoomType 校验并转换房间类型。
+func (h *RoomHandler) convertRoomType(roomType string) (protocol.RoomType, error) {
+	switch roomType {
+	case string(protocol.RoomTypePK):
+		return protocol.RoomTypePK, nil
+	case string(protocol.RoomTypeVoice):
+		return protocol.RoomTypeVoice, nil
+	}
+	return protocol.RoomType(""), fmt.Errorf("unsupported room type %s", roomType)
 }
 
 // generateRoomID 生成直播间ID。
@@ -429,29 +455,14 @@ func (h *RoomHandler) GetRoom(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, httpErr)
 		return
 	}
-	creator, err := h.Account.GetAccountByID(xl, room.Creator)
+	resp, err := h.makeGetRoomResponse(xl, room)
 	if err != nil {
-		// 获取主播账号信息失败，这里暂时用模拟的的账号信息填充。
-		xl.Errorf("failed to get user info of %s, creator of room %s", room.Creator, room.ID)
-		creator = &protocol.Account{ID: room.Creator, Nickname: "user-" + room.Creator}
+		httpErr := errors.NewHTTPErrorInternal().WithRequestID(requestID).WithMessagef("failed to get room info")
+		xl.Errorf("failed to get make get room response, error %v", err)
+		c.JSON(http.StatusInternalServerError, httpErr)
+		return
 	}
-	audienceNumber, err := h.Room.GetAudienceNumber(xl, roomID)
-	if err != nil {
-		xl.Errorf("failed to get audience number of room %s,error %v", roomID, err)
-	}
-	resp := &protocol.GetRoomResponse{
-		ID:             room.ID,
-		Name:           room.Name,
-		PlayURL:        room.PlayURL,
-		AudienceNumber: audienceNumber,
-		Status:         string(room.Status),
-		Creator: protocol.UserInfo{
-			ID:       creator.ID,
-			Nickname: creator.Nickname,
-			Gender:   creator.Gender,
-		},
-	}
-	xl.Infof("user %s get room info of room %s", userID, roomID)
+	xl.Debugf("user %s get room info of room %s", userID, roomID)
 	c.JSON(http.StatusOK, resp)
 }
 
@@ -737,9 +748,18 @@ func (h *RoomHandler) EnterRoom(c *gin.Context) {
 		Gender:   creator.Gender,
 	}
 
+	ret = &protocol.EnterRoomResponse{
+		RoomID:   updatedRoom.ID,
+		RoomName: updatedRoom.Name,
+		RoomType: string(updatedRoom.Type),
+		PlayURL:  updatedRoom.PlayURL,
+		Creator:  creatorInfo,
+		Status:   string(updatedRoom.Status),
+	}
+
 	// 获取pkAnchor的userInfo
-	pkAnchorInfo := &protocol.UserInfo{}
 	if updatedRoom.Status == protocol.LiveRoomStatusPK {
+		pkAnchorInfo := &protocol.UserInfo{}
 		pkAnchor, err := h.Account.GetAccountByID(xl, updatedRoom.PKAnchor)
 		if err != nil {
 			xl.Errorf("pkAnchor %v is not found", pkAnchor)
@@ -752,17 +772,12 @@ func (h *RoomHandler) EnterRoom(c *gin.Context) {
 			Nickname: pkAnchor.Nickname,
 			Gender:   pkAnchor.Gender,
 		}
+		ret.PKAnchor = pkAnchorInfo
 	}
-
-	ret = &protocol.EnterRoomResponse{
-		RoomID:     updatedRoom.ID,
-		RoomName:   updatedRoom.Name,
-		PlayURL:    updatedRoom.PlayURL,
-		Creator:    creatorInfo,
-		Status:     string(updatedRoom.Status),
-		PKAnchorID: pkAnchorInfo,
-		IMUser:     protocol.IMUser{},
-		IMChatRoom: protocol.IMChatRoom{},
+	// 若为语音房，为用户生成一个具有user权限的RTC房间token。
+	if updatedRoom.Type == protocol.RoomTypeVoice {
+		rtcRoomToken := h.generateRTCRoomToken(updatedRoom.ID, userID, "user")
+		ret.RTCRoomToken = rtcRoomToken
 	}
 
 	c.JSON(http.StatusOK, ret)

--- a/handler/room_test.go
+++ b/handler/room_test.go
@@ -107,18 +107,21 @@ func TestCreateRoom(t *testing.T) {
 	testCases := []struct {
 		userID             string
 		roomName           string
+		roomType           string
 		maxRooms           int
 		expectedStatusCode int
 	}{
 		{
 			userID:             "user-0",
 			roomName:           "room-0",
+			roomType:           "pk",
 			maxRooms:           10,
 			expectedStatusCode: 200,
 		},
 		{
 			userID:             "user-1",
 			roomName:           "room-1",
+			roomType:           "voice",
 			maxRooms:           10,
 			expectedStatusCode: 200,
 		},
@@ -130,19 +133,29 @@ func TestCreateRoom(t *testing.T) {
 		},
 		{
 			userID:             "user-1",
+			roomName:           "room-2",
+			roomType:           "invalid",
+			maxRooms:           10,
+			expectedStatusCode: 400,
+		},
+		{
+			userID:             "user-1",
 			roomName:           "room-1",
+			roomType:           "pk",
 			maxRooms:           1,
 			expectedStatusCode: 503,
 		},
 		{
 			userID:             "user-0",
 			roomName:           "room-1",
+			roomType:           "pk",
 			maxRooms:           10,
 			expectedStatusCode: 403,
 		},
 		{
 			userID:             "user-1",
 			roomName:           "room-0",
+			roomType:           "pk",
 			maxRooms:           10,
 			expectedStatusCode: 409,
 		},
@@ -176,6 +189,7 @@ func TestCreateRoom(t *testing.T) {
 		createRoomReq := &protocol.CreateRoomArgs{
 			UserID:   testCase.userID,
 			RoomName: testCase.roomName,
+			RoomType: testCase.roomType,
 		}
 		buf, err := json.Marshal(createRoomReq)
 		assert.Nilf(t, err, "failed to build request body for case %d, error %v", i, err)
@@ -194,12 +208,14 @@ func TestListAllRooms(t *testing.T) {
 	room0 := &protocol.LiveRoom{
 		ID:      "room-0",
 		Name:    "room0",
+		Type:    protocol.RoomTypePK,
 		Creator: "user-0",
 		Status:  protocol.LiveRoomStatusSingle,
 	}
 	pkRoom1 := &protocol.LiveRoom{
 		ID:       "pkroom-1",
 		Name:     "pk1",
+		Type:     protocol.RoomTypePK,
 		Creator:  "user-1",
 		Status:   protocol.LiveRoomStatusPK,
 		PKAnchor: "user-2",
@@ -207,6 +223,7 @@ func TestListAllRooms(t *testing.T) {
 	pkRoom2 := &protocol.LiveRoom{
 		ID:       "pkroom-2",
 		Name:     "pk2",
+		Type:     protocol.RoomTypePK,
 		Creator:  "user-2",
 		Status:   protocol.LiveRoomStatusPK,
 		PKAnchor: "user-1",

--- a/protocol/http_model.go
+++ b/protocol/http_model.go
@@ -58,8 +58,9 @@ type LoginResponse struct {
 
 // UpdateProfileArgs 修改用户信息接口。
 type UpdateProfileArgs struct {
-	Nickname string `json:"nickname"`
-	Gender   string `json:"gender"`
+	Nickname  string `json:"nickname"`
+	Gender    string `json:"gender"`
+	AvatarURL string `json:"avatar,omitempty"`
 }
 
 // UpdateProfileResponse 修改用户信息的返回结果。

--- a/protocol/http_model.go
+++ b/protocol/http_model.go
@@ -36,9 +36,10 @@ const (
 
 // UserInfo 用户的信息，包括ID、昵称等。
 type UserInfo struct {
-	ID       string `json:"id"`
-	Nickname string `json:"nickname"`
-	Gender   string `json:"gender"`
+	ID        string `json:"id"`
+	Nickname  string `json:"nickname"`
+	Gender    string `json:"gender"`
+	AvatarURL string `json:"avatar"`
 }
 
 // SMSLoginArgs 通过短信登录的参数
@@ -68,6 +69,8 @@ type UpdateProfileResponse UserInfo
 type GetRoomResponse struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+	// 房间的类型。
+	Type string `json:"type"`
 	// 创建者的用户ID
 	Creator UserInfo `json:"creator"`
 	// TODO：添加创建者的昵称/性别等信息？
@@ -99,19 +102,19 @@ type IMChatRoom struct{}
 type EnterRoomResponse struct {
 	RoomID   string `json:"roomID"`
 	RoomName string `json:"roomName"`
-	// 直播间的拉流观看地址。
+	// 房间类型。
+	RoomType string `json:"roomType"`
+	// 若为主播PK房，返回直播间的拉流观看地址。
 	PlayURL string `json:"playURL"`
+	// 若为语音房，返回加入RTC房间的token。
+	RTCRoomToken string `json:"rtcRoomToken,omitempty"`
 	// 直播间创建者信息。
 	Creator UserInfo `json:"creator"`
 	// TODO：添加创建者的昵称/性别等信息？
 	// Status 房间的状态，单人直播中/PK中
 	Status string `json:"status"`
 	// PKAnchorID 若正在PK，返回PK主播的信息。未在PK时该字段为空。
-	PKAnchorID *UserInfo `json:"pkAnchor,omitempty"`
-	// IMUser IM聊天用户信息。
-	IMUser IMUser `json:"imUser"`
-	// IMGroup IM聊天室信息。
-	IMChatRoom IMChatRoom `json:"imGroup"`
+	PKAnchor *UserInfo `json:"pkAnchor,omitempty"`
 }
 
 // LeaveRoomArgs 离开房间的请求。
@@ -123,6 +126,7 @@ type LeaveRoomArgs struct {
 // CreateRoomArgs 创建直播间的请求参数。
 type CreateRoomArgs struct {
 	UserID   string `json:"userID"`
+	RoomType string `json:"roomType"`
 	RoomName string `json:"roomName"`
 }
 
@@ -136,10 +140,6 @@ type CreateRoomResponse struct {
 	RTCRoomToken string `json:"rtcRoomToken"`
 	// WSURL websocket 信令连接的地址。
 	WSURL string `json:"wsURL"`
-	// IMUser
-	IMUser IMUser `json:"imUser"`
-	// IMGroup
-	IMChatRoom IMChatRoom `json:"imChatRoom"`
 }
 
 // CloseRoomArgs 关闭直播间参数。

--- a/qlive.conf
+++ b/qlive.conf
@@ -2,6 +2,7 @@
 {
     "debug_level":0,
     "listen_addr": ":8080",
+    "default_avatars":["1.jpg","2.jpg","3.jpg"],
     "signaling": {
         "type": "ws"
     },

--- a/service/gin_router.go
+++ b/service/gin_router.go
@@ -54,8 +54,9 @@ func NewRouter(conf *config.Config) (*gin.Engine, error) {
 	}
 
 	accountHandler := &handler.AccountHandler{
-		Account: accountController,
-		SMSCode: smsCodeController,
+		Account:           accountController,
+		SMSCode:           smsCodeController,
+		DefaultAvatarURLs: conf.DefaultAvatars,
 	}
 
 	authController, err := controller.NewAuthController(conf.Mongo.URI, conf.Mongo.Database, nil)


### PR DESCRIPTION
 为支持语音房相关http api:
- 房间增加Type字段（pk/voice），创建、列出、加入房间时添加字段表示房间类型
- 创建房间时必须传入Type(pk/voice)，否则报错
- 加入房间时如果为语音房，返回一个user权限的RTC 房间token
- 更新用户信息接口(`POST /v1/profile`) 支持添加头像URL